### PR TITLE
Define default user as :user

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Examples:
 
 Defaults:
   To set default user, create a file in ~/.grepg.yml with
-  default_user: test
+  user: test
 ```
 
 


### PR DESCRIPTION
The gem expects the default user to be defined as :user, not :default_user
